### PR TITLE
Feat/user upload 유저 프로필 이미지 업로드 (#113)

### DIFF
--- a/src/main/java/web/mvc/santa_backend/common/config/SecurityConfig.java
+++ b/src/main/java/web/mvc/santa_backend/common/config/SecurityConfig.java
@@ -89,7 +89,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests((auth) ->
                 auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/user").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/user", "/api/user/upload/profile").permitAll()
                         .requestMatchers("/api/user/username/**", "/api/user/email/**").permitAll()
                         // post 테스트
                         // .requestMatchers("/api/posts/**").permitAll()

--- a/src/main/java/web/mvc/santa_backend/user/controller/UserContoller.java
+++ b/src/main/java/web/mvc/santa_backend/user/controller/UserContoller.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import web.mvc.santa_backend.common.S3.S3Uploader;
 import web.mvc.santa_backend.common.enumtype.BlockType;
 import web.mvc.santa_backend.common.enumtype.CustomItemType;
 import web.mvc.santa_backend.common.enumtype.ReportType;
@@ -22,6 +24,7 @@ import web.mvc.santa_backend.user.dto.UserRequestDTO;
 import web.mvc.santa_backend.user.dto.UserSimpleDTO;
 import web.mvc.santa_backend.user.service.*;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -38,6 +41,7 @@ public class UserContoller {
     private final ReportService reportService;
     private final BadgeService badgeService;
     private final ColorService colorService;
+    private final S3Uploader s3Uploader;
 
     /* 회원가입 */
     @Operation(summary = "아이디(username) 중복체크")
@@ -121,6 +125,14 @@ public class UserContoller {
         UserResponseDTO updateUser = userService.updatePrivacy(customUserDetails.getUser().getUserId());
 
         return ResponseEntity.status(HttpStatus.OK).body(updateUser);
+    }
+
+    /* 프로필 이미지 업로드 */
+    @PostMapping("/upload/profile")
+    public ResponseEntity<String> upload(@RequestParam("file") MultipartFile file) throws IOException {
+        log.info("Uploading file {}", file.getOriginalFilename());
+        String url = s3Uploader.uploadFile(file, "user");
+        return ResponseEntity.status(HttpStatus.CREATED).body(url);
     }
 
     /* 유저 탈퇴(상태 수정/삭제) */


### PR DESCRIPTION
## #️⃣연관된 이슈

> #113, https://github.com/KOSTA-302-3/frontend/issues/37, https://github.com/KOSTA-302-3/frontend/issues/52

## 📝작업 내용

> 유저 프로필 이미지 업로드

## 💬리뷰 요구사항(선택)

> SecurityConfig 에서 "/api/user/upload/profile"를 permitAll로 하면 회원가입 페이지에서 업로드 악용(?)이 있을 수 있으니... 로그인 한 사용자만 가능하게 할지 고민... 회원가입 페이지에서는 기본 정보를 입력하면 회원 가입이 되고 거기서 추가 설정으로 '프로필 이미지를 바꾸시겠습니까?' 로 넘어가는 게 나으려나...