### PR TITLE
Fix/follow 팔로우 확인 로직 보완

### DIFF
--- a/src/main/java/web/mvc/santa_backend/user/controller/FollowController.java
+++ b/src/main/java/web/mvc/santa_backend/user/controller/FollowController.java
@@ -54,4 +54,11 @@ public class FollowController {
         return ResponseEntity.status(HttpStatus.OK).body(follow);
     }
 
+    @Operation(summary = "팔로우 거절", description = "비공개 유저에게 온 팔로우 요청을 거절")
+    @DeleteMapping("/refuse/{followerId}")
+    public ResponseEntity<?> refuseFollow(@PathVariable Long followerId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        followService.refuseFollow(followerId, customUserDetails.getUser().getUserId());
+
+        return ResponseEntity.status(HttpStatus.OK).body("OK");
+    }
 }

--- a/src/main/java/web/mvc/santa_backend/user/repository/FollowRepository.java
+++ b/src/main/java/web/mvc/santa_backend/user/repository/FollowRepository.java
@@ -50,4 +50,5 @@ public interface FollowRepository extends JpaRepository<Follows, Long> {
     Optional<Follows> findByFollower_UserIdAndFollowing_UserId(Long id, Long targetId);
 
     Boolean existsByFollower_UserIdAndFollowing_UserId(Long id, Long targetId);
+    Boolean existsByFollower_UserIdAndFollowing_UserIdAndPendingIsFalse(Long id, Long targetId);
 }

--- a/src/main/java/web/mvc/santa_backend/user/service/FollowService.java
+++ b/src/main/java/web/mvc/santa_backend/user/service/FollowService.java
@@ -32,6 +32,11 @@ public interface FollowService {
      */
     FollowDTO approveFollow(Long followerId, Long followingId);
 
+    /**
+     * 팔로우 대기(요청) 거절
+     */
+    void refuseFollow(Long followerId, Long followingId);
+
     /* 팔로워, 팔로잉 수 증가/감소 */
     void increaseFollowCount(Long followerId, Long followingId);
     void decreaseFollowCount(Long followerId, Long followingId);

--- a/src/main/java/web/mvc/santa_backend/user/service/FollowServiceImpl.java
+++ b/src/main/java/web/mvc/santa_backend/user/service/FollowServiceImpl.java
@@ -66,17 +66,20 @@ public class FollowServiceImpl implements FollowService {
                 .createdAt(LocalDateTime.now())
                 .build();
 
-        if (following.isPrivate() == false) {   // 공개 계정일 경우만 count 증가
-            this.increaseFollowCount(followerId, followingId);
-        }
-
         // 알림
         NotificationDTO notificationDTO = NotificationDTO.builder()
                 .userId(following.getUserId())
                 .actionUserId(follower.getUserId())
                 .type(NotificationType.FOLLOW)
-                .link(null)
+                .link("/user/" + followingId + "/follow?tab=followings")
                 .build();
+
+        if (following.isPrivate() == false) {   // 공개 계정일 경우만 count 증가
+            this.increaseFollowCount(followerId, followingId);
+        } else {
+            notificationDTO.setLink("/user/" + followingId + "/follow?tab=pendings");
+        }
+
         notificationService.createNotification(notificationDTO);
 
         followRepository.save(follow);
@@ -115,6 +118,15 @@ public class FollowServiceImpl implements FollowService {
         log.info("user {} approved the follow request from user {}", followerId, followingId);
 
         return modelMapper.map(follow, FollowDTO.class);
+    }
+
+    @Override
+    public void refuseFollow(Long followerId, Long followingId) {
+        Follows follow = followRepository.findByFollower_UserIdAndFollowing_UserId(followerId, followingId)
+                .orElseThrow(()->new InvalidException(ErrorCode.INVALID_UNFOLLOW));
+
+        followRepository.delete(follow);
+        log.info("user {} refused user {}", followerId, followingId);
     }
 
     @Transactional

--- a/src/main/java/web/mvc/santa_backend/user/service/FollowServiceImpl.java
+++ b/src/main/java/web/mvc/santa_backend/user/service/FollowServiceImpl.java
@@ -100,7 +100,7 @@ public class FollowServiceImpl implements FollowService {
 
     @Override
     public boolean isFollowing(Long followerId, Long followingId) {
-        return followRepository.existsByFollower_UserIdAndFollowing_UserId(followerId, followingId);
+        return followRepository.existsByFollower_UserIdAndFollowing_UserIdAndPendingIsFalse(followerId, followingId);
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈

> 프론트 https://github.com/KOSTA-302-3/frontend/pull/89

## 📝작업 내용

- existsByFollower_UserIdAndFollowing_UserId 에서 existsByFollower_UserIdAndFollowing_UserIdAndPendingIsFalse 로 변경
> pending 까지 확인해서 수락된 상태여야 팔로우 상태라고 인정
- 팔로우 시 비공개/공개 여부에 따라 알림의 link 값 다르게 설정
- 팔로우 요청 거절 api 추가